### PR TITLE
Adds automated installer build from AppVeyor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -222,3 +222,8 @@ gradle-app.setting
 
 #VSCode
 .vscode/
+
+temp/
+setup/
+
+!buildInstaller.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,17 @@
+version: '{branch}-{build}'
+pull_requests:
+  do_not_increment_build_number: true
+skip_branch_with_pr: true
+build_script:
+- ps: >-
+    ./buildInstaller.ps1
+    if($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode )  }
+    Get-ChildItem .\setup\Output\*.exe | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
+    Get-ChildItem .\setup\Output\*.zip | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
+deploy:
+- provider: GitHub
+  auth_token:
+    secure: iRYg7BaJ7cJ9OB18xvaOhmmhSZjN48FU2/2tB6K3qyqY2ubxOJTF2yYowAzksBYo
+  artifact: /.*\.exe/,/.*\.zip/
+  on:
+    appveyor_repo_tag: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,9 +5,13 @@ skip_branch_with_pr: true
 build_script:
 - ps: >-
     ./buildInstaller.ps1
+
     if($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode )  }
+
     Get-ChildItem .\setup\Output\*.exe | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
+
     Get-ChildItem .\setup\Output\*.zip | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
+
 deploy:
 - provider: GitHub
   auth_token:

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import org.gradle.internal.os.OperatingSystem
 
 plugins {
     id 'net.ltgt.errorprone' version '0.0.8'
-    id 'edu.wpi.first.wpilib.versioning.WPILibVersioningPlugin' version '1.4'
+    id 'edu.wpi.first.wpilib.versioning.WPILibVersioningPlugin' version '1.6'
 }
 
 allprojects {
@@ -11,9 +11,13 @@ allprojects {
     }
 }
 
-ext.useDriver = false
+if (!hasProperty('releaseType')) {
+    WPILibVersion {
+        releaseType = 'official'
+    }
+}
 
-ext.compilerPrefixToUse = project.hasProperty('compilerPrefix') ? project.compilerPrefix : 'arm-frc-linux-gnueabi-'
+ext.useDriver = false
 
 ext.setupDefines = { project, binaries ->
     binaries.all {
@@ -26,48 +30,6 @@ ext.setupDefines = { project, binaries ->
 }
 
 apply from: "locations.gradle"
-
-ext.addUserLinks = { linker, targetPlatform, implLib ->
-    def libPattern = /.*((\\/|\\).*)+lib(?<libName>.+).(.+)$/
-    def libraryArgs = []
-    def libraryPath = file(driverLibraryLib).path
-
-    // adds all libraries found in the driver folder
-    def libraryTree = fileTree(libraryPath)
-    libraryTree.include '*.so'
-    libraryTree.include '*.a'
-
-    libraryTree.each { lib ->
-        def nameMatcher = (lib.path =~ libPattern)
-        if (nameMatcher[0].size() > 1) {
-            def name = nameMatcher.group('libName')
-            libraryArgs << '-l' + name
-        }
-    }
-    
-    if (implLib) {
-        // adds all libraries found in the impl folder
-        def implLibraryPath = file(cppLibraryLib).path
-        def implLibraryTree = fileTree(implLibraryPath)
-        implLibraryTree.include '*.so'
-        implLibraryTree.include '*.a'
-
-        implLibraryTree.each { lib ->
-            def nameMatcher = (lib.path =~ libPattern)
-            if (nameMatcher[0].size() > 1) {
-                def name = nameMatcher.group('libName')
-                libraryArgs << '-l' + name
-            }
-        }
-    }
-     
-    // Add all arguments
-    String architecture = targetPlatform.architecture
-    if (architecture.contains('arm')){
-        linker.args << '-L' + libraryPath
-        linker.args.addAll(libraryArgs)
-    }
-}
 
 apply from: "properties.gradle"
 
@@ -84,6 +46,8 @@ task build
 
 apply from: "releases.gradle"
 
+apply from: "installer.gradle"
+
 task clean(type: Delete) {
     description = "Deletes the build directory"
     group = "Build"
@@ -92,6 +56,7 @@ task clean(type: Delete) {
 
 clean {
     delete releaseDir
+    delete setupDir
 }
 
 task wrapper(type: Wrapper) {

--- a/buildInstaller.ps1
+++ b/buildInstaller.ps1
@@ -1,0 +1,48 @@
+if ($env:APPVEYOR) {
+    $localFolder = "$env:APPVEYOR_BUILD_FOLDER\temp"
+} else {
+    $localFolder = ".\temp"
+}
+
+# Create temp directory to store stuff in
+if ((Test-Path $localFolder) -eq $false) {
+  md $localFolder
+}
+
+$compilerName = "compiler"
+
+echo "Downloading Compiler"
+(New-Object System.Net.WebClient).DownloadFile("http://first.wpi.edu/FRC/roborio/toolchains/FRC-2017-Windows-Toolchain-4.9.3.zip", "$localFolder\$compilerName.zip")
+
+# unzip everything
+Add-Type -assembly "system.io.compression.filesystem"
+
+function Unzip($file)
+{
+  [io.compression.zipfile]::ExtractToDirectory("$localFolder\$file.zip", "$localFolder\$file")
+}
+
+echo "Extracting Compiler"
+Unzip($compilerName)
+
+echo "Adding compiler to path"
+$comp = "$localFolder\compiler\frc\bin"
+
+$exePath = "$env:USERPROFILE\innosetup-5.5.9-unicode.exe"
+ 
+Write-Host "Downloading InnoSetup 5.5.9..."
+(New-Object Net.WebClient).DownloadFile('http://files.jrsoftware.org/is/5/innosetup-5.5.9-unicode.exe', $exePath)
+ 
+Write-Host "Installing..."
+cmd /c start /wait $exePath /silent
+ 
+Write-Host "Installed InnoSetup 5.5.9" -ForegroundColor Green
+
+$env:PATH += ";C:\Program Files (x86)\Inno Setup 5"
+$env:PATH += ";C:\Program Files\Inno Setup 5"
+
+if ($env:APPVEYOR) {
+    .\gradlew installer windowsZip -PtoolChainPath="$comp" -PjenkinsBuild
+} else {
+    .\gradlew installer windowsZip -PtoolChainPath="$comp"
+}

--- a/cpp.gradle
+++ b/cpp.gradle
@@ -13,7 +13,6 @@ def cppSetupModel = { project ->
                 binaries.all {
                     tasks.withType(CppCompile) {
                         cppCompiler.args "-DNAMESPACED_WPILIB"
-                        addUserLinks(linker, targetPlatform, false)
                         addHalLibraryLinks(it, linker, targetPlatform)
                         addWpiUtilLibraryLinks(it, linker, targetPlatform)
                         addNetworkTablesLibraryLinks(it, linker, targetPlatform)

--- a/installer.gradle
+++ b/installer.gradle
@@ -1,36 +1,12 @@
-task javaSourceJar(type: Jar) {
-    description = 'Generates the source jar for java'
-    group = 'WPILib'
-    baseName = libraryName
-    classifier = "sources"
-    duplicatesStrategy = 'exclude'
-    destinationDir = releaseDir
-    
-    dependsOn project(':arm:cpp').classes
-    from project(':arm:cpp').sourceSets.main.allJava
-}
+ext.setupDir = file("${rootDir}/setup")
 
-task javaJavadocJar(type: Jar) {
-    description = 'Generates the javadoc jar for java'
-    group = 'WPILib'
-    baseName = libraryName
-    classifier = "javadoc"
-    duplicatesStrategy = 'exclude'
-    destinationDir = releaseDir
-    
-    dependsOn project(':arm:cpp').javadoc
-    from project(':arm:cpp').javadoc.destinationDir
-}
-
-task userStaticZip(type: Zip) {
+task copyForSetup(type: Copy) {
     description = 'Creates user zip of libraries, with static c++ libs.'
     group = 'WPILib'
-    destinationDir = releaseDir
-    baseName = libraryName
-    classifier = 'user'
+    destinationDir = setupDir
     duplicatesStrategy = 'exclude'
     
-    // Copy include files from cpp project
+        // Copy include files from cpp project
     from(file(cppInclude)) {
         include '**/*.h'
         into '/cpp/include'
@@ -173,62 +149,42 @@ task userStaticZip(type: Zip) {
     }
 }
 
-task cppSources(type: Zip) {
-    description = 'Creates a zip of cpp sources.'
-    group = 'WPILib'
-    destinationDir = releaseDir
-    baseName = libraryName
-    classifier = 'cppsources'
-    duplicatesStrategy = 'exclude'
-    
-    from(cppSrc) {
-        into 'src'
-    }
-
-    from(cppInclude) {
-        into 'include'
-    }
-}
-
-if (useDriver) {
-    task driverSources(type: Zip) {
-        description = 'Creates a zip of driver sources.'
-        group = 'WPILib'
-        destinationDir = releaseDir
-        baseName = libraryName
-        classifier = 'driversources'
-        duplicatesStrategy = 'exclude'
-        
-        from(driverSrc) {
-            into 'src'
-        }
-
-        from(driverInclude) {
-            into 'include'
-        }
-    }
-}
-
 project(':arm:cpp').tasks.whenTaskAdded { task ->
     def name = task.name.toLowerCase()
     if (name.contains("sharedlibrary") || name.contains("staticlibrary")) {
-        userStaticZip.dependsOn task
+        copyForSetup.dependsOn task
     }
 }
 
-if (useDriver) {
-    project(':arm:driver').tasks.whenTaskAdded { task ->
-        def name = task.name.toLowerCase()
-        if (name.contains("sharedlibrary") || name.contains("staticlibrary")) {
-            userStaticZip.dependsOn task
+task windowsZip(type: Copy) {
+    dependsOn userStaticZip
+    destinationDir = file("${setupDir}/output")
+
+    from (userStaticZip.outputs.files.singleFile) {
+        rename("(.*).zip", "CANJaguar_Libs_${(WPILibVersion.version).replace(".", "_")}.zip") 
+    }
+}
+
+// https://github.com/syncany/syncany/tree/master/gradle/innosetup
+// Skeleton code found here
+task installer() {
+    dependsOn copyForSetup
+
+    doLast {
+        delete "${setupDir}/setup.iss"
+
+        copy {
+            from("${rootDir}/setup.iss.skel")
+            rename("setup.iss.skel", "setup.iss")
+            expand([
+            applicationVersion: "${WPILibVersion.version}"
+            ])
+            into(setupDir)
+        }
+
+        exec {
+            workingDir rootDir
+            commandLine "iscc ${setupDir}/setup.iss".split()
         }
     }
-}
-
-build.dependsOn javaSourceJar
-build.dependsOn javaJavadocJar
-build.dependsOn userStaticZip
-build.dependsOn cppSources
-if (useDriver) {
-    build.dependsOn driverSources
 }

--- a/setup.iss.skel
+++ b/setup.iss.skel
@@ -3,7 +3,6 @@
 
 #define MyAppName "CANJaguar software libraries"
 #define MyAppShortName "CANJaguar"
-#define MyAppVersion "1.0.0"
 #define MyAppPublisher "FIRST"
 #define MyAppURL "http://www.firstinspires.org"
 
@@ -13,16 +12,16 @@
 ; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
 AppId={{01A68915-B6D3-4D8E-A498-43744E3FC5FD}
 AppName={#MyAppName}
-AppVersion={#MyAppVersion}
+AppVersion=${applicationVersion}
 ;AppVerName={#MyAppName} {#MyAppVersion}
 AppPublisher={#MyAppPublisher}
 AppPublisherURL={#MyAppURL}
 AppSupportURL={#MyAppURL}
 AppUpdatesURL={#MyAppURL}
-DefaultDirName={%USERPROFILE}\wpilib\user
+DefaultDirName={%USERPROFILE}\\wpilib\\user
 UninstallDisplayName=Uninstall_{#MyAppName}
 DefaultGroupName={#MyAppName}
-OutputBaseFilename=setup
+OutputBaseFilename=CANJaguar_Libs_${applicationVersion}
 Compression=lzma
 SolidCompression=yes
 Uninstallable=no
@@ -31,8 +30,8 @@ Uninstallable=no
 Name: "english"; MessagesFile: "compiler:Default.isl"
 
 [Files]
-Source: "release\cpp\*"; DestDIR: "{app}\cpp"; Flags: ignoreversion recursesubdirs createallsubdirs
-Source: "release\java\*"; DestDIR: "{app}\java"; Flags: ignoreversion recursesubdirs createallsubdirs
-Source: "lv\*"; DestDir: "{pf}\National Instruments\LabVIEW 2016\vi.lib\Rock Robotics\WPI\ThirdParty\CanMotor"; Flags: ignoreversion recursesubdirs
+Source: "cpp\\*"; DestDIR: "{app}\\cpp"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "java\\*"; DestDIR: "{app}\\java"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "..\\lv\\*"; DestDir: "{pf}\\National Instruments\\LabVIEW 2016\\vi.lib\\Rock Robotics\\WPI\\ThirdParty\\CanMotor"; Flags: ignoreversion recursesubdirs
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 


### PR DESCRIPTION
Using the buildInstaller.ps1 powershell script will download the compiler, download the installer build program, and build a version of the installer. When ran on AppVeyor, will publish the builds to the AppVeyor artifacts page, and on a git tag, will push the release to the tag to automatically create the release. So all that will be required to run a build will just be properly tagging the repo.

Note the publishing will not work properly until AppVeyor gets set up, and the API key in appveyor.yml gets updated to one for the frcjenkins AppVeyor account. But everything else works.

Sorry no linux installer build yet.